### PR TITLE
[BUG] When debounce with `leadingEdge` or `leadingAndTrailing`, callback is immediately called everytime

### DIFF
--- a/lib/src/debouncer.dart
+++ b/lib/src/debouncer.dart
@@ -28,16 +28,23 @@ class Debouncer {
   void debounce({
     required Duration duration,
     required Function() onDebounce,
-    @Deprecated("Please use the 'type' parameter instead.") bool isLeadingEdge = false,
+    @Deprecated("Please use the 'type' parameter instead.")
+    bool isLeadingEdge = false,
     BehaviorType type = BehaviorType.trailingEdge,
   }) {
-    if (type == BehaviorType.leadingEdge || type == BehaviorType.leadingAndTrailing) {
+    // If we aren't in a debounce period, and we should call the callback
+    // on the leading edge, then call the callback immediately
+    if (_debounceTimer == null &&
+        (type == BehaviorType.leadingEdge ||
+            type == BehaviorType.leadingAndTrailing)) {
       onDebounce();
     }
 
     _debounceTimer?.cancel();
     _debounceTimer = Timer(duration, () {
-      if (type == BehaviorType.trailingEdge || type == BehaviorType.leadingAndTrailing) {
+      _debounceTimer = null;
+      if (type == BehaviorType.trailingEdge ||
+          type == BehaviorType.leadingAndTrailing) {
         onDebounce();
       }
     });
@@ -49,5 +56,6 @@ class Debouncer {
   /// debounced callback associated with that timer will not be invoked.
   void cancel() {
     _debounceTimer?.cancel();
+    _debounceTimer = null;
   }
 }

--- a/test/debouncer_test.dart
+++ b/test/debouncer_test.dart
@@ -26,7 +26,8 @@ void main() {
       expect(callbackCalled, true);
     });
 
-    test('Multiple calls within the debounce duration cancel previous timers', () async {
+    test('Multiple calls within the debounce duration cancel previous timers',
+        () async {
       final debouncer = Debouncer();
       var callbackCalledCount = 0;
       const duration = Duration(milliseconds: 500);
@@ -89,54 +90,226 @@ void main() {
       expect(callbackCalled, false);
     });
 
-    test('Leading edge: Callback is called immediately on the first call', () async {
+    test(
+        'Leading edge: Callback is called immediately on first call'
+        ' and subsequent calls are ignored during debounce period', () async {
       final debouncer = Debouncer();
-      var callbackCalled = false;
-      const duration = Duration(milliseconds: 500);
+      var callbackCalledCount = 0;
+      const debounceDuration = Duration(milliseconds: 500);
+      const initialDelay = Duration(milliseconds: 200);
+      const safetyMargin = Duration(milliseconds: 10);
 
       debouncer.debounce(
-        duration: duration,
+        duration: debounceDuration,
         type: BehaviorType.leadingEdge,
         onDebounce: () {
-          callbackCalled = true;
+          callbackCalledCount++;
         },
       );
 
-      // Wait for a shorter duration than the debounce duration
-      await Future.delayed(const Duration(milliseconds: 100));
+      // Callback should be called immediately on first call
+      expect(callbackCalledCount, 1);
 
-      expect(callbackCalled, true);
+      // Wait for a duration shorter than debounce period
+      await Future.delayed(initialDelay);
 
-      // Wait for the debounce duration to elapse
-      await Future.delayed(duration);
+      // Second call within debounce period
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingEdge,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
 
-      // Ensure that the callback is called only once
-      expect(callbackCalled, true);
+      // Callback count should remain the same as second call is ignored
+      expect(callbackCalledCount, 1);
+
+      // Wait until the debounce period should have expired if we didn't have
+      // the 2nd call
+      final oriEndDelay = debounceDuration - initialDelay + safetyMargin;
+      await Future.delayed(oriEndDelay);
+
+      // Callback count should still be 1 as the timer was reset
+      expect(callbackCalledCount, 1);
+
+      // Wait for full debounce duration to ensure no additional calls
+      await Future.delayed(debounceDuration - oriEndDelay + safetyMargin);
+
+      // Final verification that callback was only called once
+      expect(callbackCalledCount, 1);
     });
 
-    test('Trailing and Leading Edge: Callback is called immediately on the first call and after the specified duration', () async {
+    test(
+        'Leading edge: Calling after the debounce period will start a new period',
+        () async {
       final debouncer = Debouncer();
-      var callbackCalled = false;
-      const duration = Duration(milliseconds: 500);
+      var callbackCalledCount = 0;
+      const debounceDuration = Duration(milliseconds: 500);
+      const safetyMargin = Duration(milliseconds: 10);
 
       debouncer.debounce(
-        duration: duration,
-        type: BehaviorType.leadingAndTrailing,
+        duration: debounceDuration,
+        type: BehaviorType.leadingEdge,
         onDebounce: () {
-          callbackCalled = !callbackCalled;
+          callbackCalledCount++;
         },
       );
 
-      // Wait for a shorter duration than the debounce duration
-      await Future.delayed(const Duration(milliseconds: 100));
+      // Callback should be called immediately on first call
+      expect(callbackCalledCount, 1);
 
-      expect(callbackCalled, true);
+      // Wait for the debounce period to elapse
+      await Future.delayed(debounceDuration + safetyMargin);
 
-      // Wait for the debounce duration to elapse
-      await Future.delayed(duration);
+      // Second call after 1st debounce period
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingEdge,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
 
-      // Ensure that the callback is called only once
-      expect(callbackCalled, false);
+      // Callback should be called again because a new debounce period has started
+      expect(callbackCalledCount, 2);
+    });
+
+    test('Leading edge: Calling after cancel will start a new period',
+        () async {
+      final debouncer = Debouncer();
+      var callbackCalledCount = 0;
+      const debounceDuration = Duration(milliseconds: 500);
+      const initialDelay = Duration(milliseconds: 100);
+
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingEdge,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
+
+      // Callback should be called immediately on first call
+      expect(callbackCalledCount, 1);
+
+      // Wait for a duration shorter than debounce period
+      await Future.delayed(initialDelay);
+
+      // Cancel the debounce timer
+      debouncer.cancel();
+
+      // Second call after cancel
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingEdge,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
+
+      // Callback should be called again because a new debounce period has started
+      expect(callbackCalledCount, 2);
+    });
+
+    test(
+        'Trailing and Leading Edge: Callback is called immediately on the first'
+        ' call and after the specified duration', () async {
+      final debouncer = Debouncer();
+      var callbackCalledCount = 0;
+      const debounceDuration = Duration(milliseconds: 500);
+      const initialDelay = Duration(milliseconds: 200);
+      const safetyMargin = Duration(milliseconds: 10);
+
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingAndTrailing,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
+
+      // Callback should be called immediately on first call
+      expect(callbackCalledCount, 1);
+
+      // Wait for a duration shorter than debounce period
+      await Future.delayed(initialDelay);
+
+      // Second call within debounce period
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingAndTrailing,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
+
+      // Callback count should remain the same as second call is ignored
+      expect(callbackCalledCount, 1);
+
+      // Wait until the debounce period should have expired if we didn't have
+      // the 2nd call
+      final oriEndDelay = debounceDuration - initialDelay + safetyMargin;
+      await Future.delayed(oriEndDelay);
+
+      // Callback count should still be 1 as the timer was reset
+      expect(callbackCalledCount, 1);
+
+      // Wait until just before the debounce period
+      await Future.delayed(debounceDuration - oriEndDelay - safetyMargin);
+
+      // The callback shouldn't be called yet
+      expect(callbackCalledCount, 1);
+
+      // Wait for the debounce period to elapse
+      await Future.delayed(safetyMargin * 2);
+
+      // Callback should be called again after the debounce period
+      expect(callbackCalledCount, 2);
+    });
+
+    test(
+        'Trailing and Leading Edge: Calling after the debounce period will'
+        ' start a new period', () async {
+      final debouncer = Debouncer();
+      var callbackCalledCount = 0;
+      const debounceDuration = Duration(milliseconds: 500);
+      const safetyMargin = Duration(milliseconds: 10);
+
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingAndTrailing,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
+
+      // Callback should be called immediately on first call
+      expect(callbackCalledCount, 1);
+
+      // Wait for the debounce period to elapse
+      await Future.delayed(debounceDuration + safetyMargin);
+
+      // Callback should be called after the debounce period
+      expect(callbackCalledCount, 2);
+
+      // Second call after the 1st debounce period
+      debouncer.debounce(
+        duration: debounceDuration,
+        type: BehaviorType.leadingAndTrailing,
+        onDebounce: () {
+          callbackCalledCount++;
+        },
+      );
+
+      // Callback should be called again because a new debounce period has started
+      expect(callbackCalledCount, 3);
+
+      // Wait for the 2nd debounce period to elapse
+      await Future.delayed(debounceDuration + safetyMargin);
+
+      // Callback should be called again after the 2nd debounce period
+      expect(callbackCalledCount, 4);
     });
   });
 }


### PR DESCRIPTION
Observed behavior:
Originally, when using a debouncer with type = `leadingEdge` or `leadingAndTrailingEdge`, the callback is immediately called every time the `debounce()` is called. 

Expected behavior: 
The calls should be ignored during the debounce period.
